### PR TITLE
Add pathfinding informations & improve debug tool look

### DIFF
--- a/tool/outech-debug/.gitignore
+++ b/tool/outech-debug/.gitignore
@@ -4,6 +4,8 @@
 /node_modules
 /.pnp
 .pnp.js
+# not supposed to be public
+package-lock.json
 
 # testing
 /coverage

--- a/tool/outech-debug/README.md
+++ b/tool/outech-debug/README.md
@@ -1,4 +1,14 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# OUTech-debug Tool
+
+A tool to render debug informations - bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+
+## Actions view
+
+## Encoder graph view
+
+## Simulation view
+
+This view prints [high level](https://github.com/outech-robotic/code/tree/master/highlevel)'s layer informations, such as robot's position & angle. 
 
 ## Available Scripts
 
@@ -47,27 +57,3 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `yarn build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify

--- a/tool/outech-debug/package.json
+++ b/tool/outech-debug/package.json
@@ -13,8 +13,9 @@
     "react": "^16.13.1",
     "react-chartjs-2": "^2.9.0",
     "react-dom": "^16.13.1",
+    "react-json-view": "^1.19.1",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.1"
+    "react-scripts": "^3.4.3"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/tool/outech-debug/public/index.html
+++ b/tool/outech-debug/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>OUTech Debug</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/tool/outech-debug/src/components/App.css
+++ b/tool/outech-debug/src/components/App.css
@@ -1,0 +1,23 @@
+nav ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    background-color: #333;
+}
+
+nav ul li {
+    float: left;
+}
+  
+nav ul li a {
+    display: block;
+    color: white;
+    text-align: center;
+    padding: 14px 16px;
+    text-decoration: none;
+}
+  
+nav ul li a:hover {
+    background-color: #111;
+}

--- a/tool/outech-debug/src/components/App.js
+++ b/tool/outech-debug/src/components/App.js
@@ -6,7 +6,7 @@ import ActionsView from "./ActionsView";
 import "./App.css"
 import SimulationView from "./SimulationView";
 import useFilterEvent from "../hooks/useFilterEvent";
-import {getLast, getValue, mapEventsToPoint} from "../event";
+import {getValue, mapEventsToPoint} from "../event";
 import useAggregatedGraph from "../hooks/useAggregatedGraph";
 import useLast from "../hooks/useLast";
 
@@ -19,6 +19,7 @@ const useDataSeries = (event$, name) => {
 function DebugInterface({event$, actionURL}) {
     const configurationEvents = useFilterEvent(event$, "configuration")
     const configuration = getValue(useLast(configurationEvents))
+    const graph = getValue(useLast(useFilterEvent(event$, "graph")))
 
     const encoderLeft = useDataSeries(event$, "encoder_left")
     const speedLeft = useDataSeries(event$, "speed_left")
@@ -51,6 +52,7 @@ function DebugInterface({event$, actionURL}) {
                             robotPositionEvent={robotPositionEvent}
                             robotAngleEvent={robotAngleEvent}
                             configuration={configuration}
+                            graph={graph}
                         />
                     </Route>
                     <Route path="/actions">
@@ -72,7 +74,6 @@ function DebugInterface({event$, actionURL}) {
         </HashRouter>
     );
 }
-
 
 export default function App() {
     const urlParams = new URLSearchParams(window.location.search);
@@ -104,5 +105,3 @@ export default function App() {
         <DebugInterface event$={event$} actionURL={actionURL}/>
     )
 }
-
-

--- a/tool/outech-debug/src/components/SimulationView.css
+++ b/tool/outech-debug/src/components/SimulationView.css
@@ -9,11 +9,23 @@
     background-color: black;
 }
 
-.json-view {
+.column-left {
     float: left;
+    width: 30%;
+    height: 90vh;
 }
 
-.table-view {
+.json-panel {
+    height: 60%;
+    width: inherit;
+}
+
+.control-panel {
+    height: 40%;
+    width: inherit;
+}
+
+.main-view {
     float: right;
-    width: 80%;
+    padding: 20px;
 }

--- a/tool/outech-debug/src/components/SimulationView.css
+++ b/tool/outech-debug/src/components/SimulationView.css
@@ -9,3 +9,11 @@
     background-color: black;
 }
 
+.json-view {
+    float: left;
+}
+
+.table-view {
+    float: right;
+    width: 80%;
+}

--- a/tool/outech-debug/src/components/SimulationView.js
+++ b/tool/outech-debug/src/components/SimulationView.js
@@ -4,6 +4,7 @@ import plateauImg from '../plateau.svg'
 import robotImg from '../robot.svg'
 import {getValue} from "../event";
 import useInterval from "../hooks/usePeriodicInterval";
+import ReactJson from 'react-json-view'
 
 
 const WIDTH = 3000;
@@ -193,6 +194,10 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
 
     const robotPosition = getValue(robotPositionEvent)
     const robotAngle = getValue(robotAngleEvent)
+    const robotState = {
+        position: robotPosition,
+        angle: robotAngle
+    }
 
     useInterval(() => {
         const canvas = document.getElementById('robotField');
@@ -213,13 +218,16 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
     }, 1000 / FPS);
 
     return <div>
-        Robot position: {JSON.stringify(robotPositionEvent)}
-        Robot angle: {robotAngle}
-        <canvas id="robotField" width="3000" height="2000">
+        <section className="json-view">
+            <ReactJson src={robotState} displayDataTypes={false} displayObjectSize={false}/>
+        </section>
+        <section className="table-view">
+            <canvas id="robotField" width="3000" height="2000">
             This page does not work, get a better (newer) browser.
-        </canvas>
-        <img alt="plateau" ref={boardImageRef} src={plateauImg} style={{display: "none"}}/>
-        <img alt="robot" ref={robotImageRef} src={robotImg} style={{display: "none"}}/>
+            </canvas>
+            <img alt="plateau" ref={boardImageRef} src={plateauImg} style={{display: "none"}}/>
+            <img alt="robot" ref={robotImageRef} src={robotImg} style={{display: "none"}}/>
+        </section>
     </div>
 
 }

--- a/tool/outech-debug/src/components/SimulationView.js
+++ b/tool/outech-debug/src/components/SimulationView.js
@@ -10,130 +10,7 @@ import ReactJson from 'react-json-view'
 const WIDTH = 3000;
 const HEIGHT = 2000;
 const FPS = 60;
-//
-//
-// let robot_width = 0;
-// let robot_height = 0;
-//
-// let getFrame = null;
-//
-// async function init() {
-//     const params = new URLSearchParams(window.location.search);
-//     const replayURL = params.get('replay');
-//     if (!replayURL) {
-//         return
-//     }
-//     if (replayURL.startsWith('ws://')) {
-//         let socket = new WebSocket(replayURL);
-//         let position = {
-//             "x": 0,
-//             "y": 0,
-//         }
-//         let angle = 0;
-//         socket.onmessage = function (event) {
-//             let currentFrame = JSON.parse(event.data);
-//             for (let f of currentFrame) {
-//                 if (f.key === "position") {
-//                     position = f.defaultValue;
-//                 }
-//                 if (f.key === "angle") {
-//                     angle = f.defaultValue;
-//                 }
-//             }
-//         };
-//         robot_width = 240;
-//         robot_height = 380;
-//         getFrame = function () {
-//             return {
-//                 "position": position,
-//                 "angle": angle,
-//             }
-//         }
-//     } else if (replayURL.startsWith("http")) {
-//         const simulation = await loadReplay(replayURL);
-//
-//         const config = simulation.events.find(e => e.key == 'configuration').defaultValue;
-//         robot_width = config.robot_length;
-//         robot_height = config.robot_width;
-//
-//         let frames = simulation.events;
-//         let start_time = Date.now();
-//         let replay_cursor = 0;
-//         let position = {
-//             "x": 0,
-//             "y": 0,
-//         }
-//         let angle = 0;
-//         getFrame = function () {
-//             const t = Date.now() - start_time;
-//             while (replay_cursor + 1 < frames.length && t > frames[replay_cursor + 1].time * 1000) {
-//                 let f = frames[replay_cursor];
-//                 if (f.key === "position") {
-//                     position = f.defaultValue;
-//                 }
-//                 if (f.key === "angle") {
-//                     angle = f.defaultValue;
-//                 }
-//                 replay_cursor += 1;
-//             }
-//             return {
-//                 "position": position,
-//                 "angle": angle,
-//             }
-//         };
-//     } else {
-//         return
-//     }
-//     window.requestAnimationFrame(draw);
-// }
 
-// window.addEventListener('load', init);
-
-// function draw() {
-//     const robot = getFrame();
-//
-//     const canvas = document.getElementById('robotField');
-//     if (!canvas.getContext) {
-//         return;
-//     }
-//     const ctx = canvas.getContext('2d');
-//
-//     ctx.globalCompositeOperation = 'source-over';
-//     ctx.clearRect(0, 0, WIDTH, HEIGHT);
-//     ctx.save();
-//
-//     drawBackground(ctx);
-//
-//     drawGrid(ctx, robot.obstacle_grid);
-//
-//     drawRobot(ctx, robot.position, robot.angle);
-//
-//     var list_obstacles = robot['position_obstacles'];
-//
-//     if (list_obstacles !== undefined) {
-//         for (var obstacle of list_obstacles) {
-//             drawObstacle(ctx, obstacle.x, obstacle.y);
-//         }
-//     }
-//
-//     ctx.restore();
-//
-//     window.requestAnimationFrame(draw);
-// }
-//
-//
-//
-// function drawGrid(ctx, grid = []) {
-//     ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
-//     for (var [x, row] of grid.entries()) {
-//         for (var y = 0; y < row.length; y++) {
-//             if (row[y] === '1') {
-//                 ctx.fillRect(x * 10, HEIGHT - y * 10, 10, 10);
-//             }
-//         }
-//     }
-// }
-//
 function drawRobot(ctx, pos, angle, robot_width, robot_height, img) {
     if (pos === undefined) {
         return
@@ -170,25 +47,32 @@ function drawRobot(ctx, pos, angle, robot_width, robot_height, img) {
     ctx.restore();
 }
 
-//
-//
-// function drawObstacle(ctx, posX, posY) {
-//     ctx.save();
-//
-//     ctx.beginPath();
-//     ctx.arc(posX, HEIGHT - posY, 5, 0, 2 * Math.PI, true);
-//     ctx.fillStyle = 'red';
-//     ctx.fill();
-//
-//     ctx.strokeStyle = '#300000';
-//     ctx.stroke();
-//
-//     ctx.restore();
-// }
-//
+function drawGraph(ctx, nodes) {
+    if (nodes === undefined) {
+        console.log("nodes undefined")
+        return
+    }
+    ctx.save();
+    ctx.fillStyle = "rgba(240,0,200,0.4)";
+    ctx.strokeStyle = "rgba(240,0,100,0.8)";
+    nodes.forEach((node) => {
+        ctx.beginPath();
+        ctx.arc(node.position.x, HEIGHT - node.position.y, 10, 0, 2*Math.PI);
+        if (node.neighbours !== undefined) {
+            node.neighbours.filter(neighbourKey => neighbourKey > node.id)
+                            .forEach((neighbourKey) => {
+                                var neighbour = nodes[neighbourKey];
+                                ctx.moveTo(node.position.x, HEIGHT - node.position.y);
+                                ctx.lineTo(neighbour.position.x, HEIGHT - neighbour.position.y);
+                                ctx.stroke();
+                            });
+        }
+        ctx.fill();
+    });
+    ctx.restore();
+}
 
-
-export default function SimulationView({robotPositionEvent, robotAngleEvent, configuration}) {
+export default function SimulationView({robotPositionEvent, robotAngleEvent, configuration, graph}) {
     const boardImageRef = React.useRef()
     const robotImageRef = React.useRef()
 
@@ -214,6 +98,9 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
         if (configuration !== undefined) {
             drawRobot(ctx, robotPosition, robotAngle, configuration.robot_length, configuration.robot_width, robotImageRef.current)
         }
+        if (graph !== undefined) {
+            drawGraph(ctx, graph.nodes);
+        }
         ctx.restore();
     }, 1000 / FPS);
 
@@ -229,5 +116,4 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
             <img alt="robot" ref={robotImageRef} src={robotImg} style={{display: "none"}}/>
         </section>
     </div>
-
 }

--- a/tool/outech-debug/src/components/SimulationView.js
+++ b/tool/outech-debug/src/components/SimulationView.js
@@ -107,14 +107,18 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
     }, 1000 / FPS);
 
     return <div>
-        <section className="json-view">
-            <ReactJson src={robotState} displayDataTypes={false} displayObjectSize={false}/>
-            <label>
-                <input type="checkbox" checked={filterGraph} onChange={(e) => setFilterGraph(e.target.checked)}/>
-                Filter graph
-            </label>
+        <section className="column-left">
+            <section className="json-panel">
+                <ReactJson src={robotState} displayDataTypes={false} displayObjectSize={false}/>
+            </section>
+            <section className="control-panel">
+                <label>
+                    <input type="checkbox" checked={filterGraph} onChange={(e) => setFilterGraph(e.target.checked)}/>
+                    Filter graph
+                </label>
+            </section>
         </section>
-        <section className="table-view">
+        <section className="main-view">
             <canvas id="robotField" width="3000" height="2000">
             This page does not work, get a better (newer) browser.
             </canvas>

--- a/tool/outech-debug/src/components/SimulationView.js
+++ b/tool/outech-debug/src/components/SimulationView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import './SimulationView.css'
 import plateauImg from '../plateau.svg'
 import robotImg from '../robot.svg'
@@ -83,6 +83,8 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
         angle: robotAngle
     }
 
+    const [filterGraph, setFilterGraph] = useState(false);
+
     useInterval(() => {
         const canvas = document.getElementById('robotField');
         if (!canvas.getContext) {
@@ -98,7 +100,7 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
         if (configuration !== undefined) {
             drawRobot(ctx, robotPosition, robotAngle, configuration.robot_length, configuration.robot_width, robotImageRef.current)
         }
-        if (graph !== undefined) {
+        if (graph !== undefined && !filterGraph) {
             drawGraph(ctx, graph.nodes);
         }
         ctx.restore();
@@ -107,6 +109,10 @@ export default function SimulationView({robotPositionEvent, robotAngleEvent, con
     return <div>
         <section className="json-view">
             <ReactJson src={robotState} displayDataTypes={false} displayObjectSize={false}/>
+            <label>
+                <input type="checkbox" checked={filterGraph} onChange={(e) => setFilterGraph(e.target.checked)}/>
+                Filter graph
+            </label>
         </section>
         <section className="table-view">
             <canvas id="robotField" width="3000" height="2000">

--- a/tool/outech-debug/src/hooks/usePeriodicInterval.js
+++ b/tool/outech-debug/src/hooks/usePeriodicInterval.js
@@ -2,7 +2,7 @@
 From https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 Thanks to the author!
  */
-import React, {useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 
 export default function useInterval(callback, delay) {
     const savedCallback = useRef();


### PR DESCRIPTION
Improve OUTech debug tool & simulation view - closes #68 : 
- Add css & layout to the debug tool
- Add graph informations to the simulation's view. It can be filtered for performance purpose. To be printable, entry `json` file should have an event with following syntax : 
```json
{
    "time": 1.23,
    "key": "graph",
    "value": {
        "nodes": [
            {
                "id": 0,
                "position": {
                    "x": 100,
                    "y": 200
                },
                "neighbours": [ 1, 2 ]
            },
            {
                "id": 1,
                "position": {
                    "x": 100,
                    "y": 300
                },
                "neighbours": [ 0, 2 ]
            },
            {
                "id": 2,
                "position": {
                    "x": 200,
                    "y": 250
                },
                "neighbours": [ 0, 1 ]
            }
        ]
    }
}
```